### PR TITLE
feat: AWS ECSを使用したWebアプリケーション環境を構築する

### DIFF
--- a/cloud_formation/web_service_with_ecs/README.md
+++ b/cloud_formation/web_service_with_ecs/README.md
@@ -9,6 +9,7 @@
 ```sh
 aws cloudformation create-stack \
    --stack-name play-with-aws-web-service-with-ecs \
+   --capabilities CAPABILITY_NAMED_IAM \
    --template-body file://main.yaml \
    --tags Key=Project,Value=play_with_aws Key=Identifier,Value=web_service_with_ecs
 ```
@@ -16,7 +17,9 @@ aws cloudformation create-stack \
 ### 更新コマンド
 
 ```sh
-aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs --template-body file://main.yaml
+aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --template-body file://main.yaml
 ```
 
 ### 削除コマンド

--- a/cloud_formation/web_service_with_ecs/README.md
+++ b/cloud_formation/web_service_with_ecs/README.md
@@ -4,7 +4,8 @@
 
 ## 手順
 
-### 作成コマンド
+#### スタックの作成
+
 ```sh
 aws cloudformation create-stack \
    --stack-name play-with-aws-web-service-with-ecs-ecr \
@@ -12,6 +13,30 @@ aws cloudformation create-stack \
    --template-body file://ecr.yaml \
    --tags Key=Project,Value=play_with_aws Key=Identifier,Value=web_service_with_ecs Key=CmBillingGroup,Value=play_with_aws_web_service_with_ecs
 ```
+
+#### スタックの更新
+
+```sh
+aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs-ecr \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --template-body file://ecr.yaml
+```
+
+#### スタックの削除
+
+```sh
+aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs-ecr
+```
+
+#### イベントの確認
+
+```sh
+aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs-ecr
+```
+
+### Webアプリケーション環境の構築
+
+#### スタックの作成
 
 ```sh
 aws cloudformation create-stack \
@@ -21,12 +46,7 @@ aws cloudformation create-stack \
    --tags Key=Project,Value=play_with_aws Key=Identifier,Value=web_service_with_ecs Key=CmBillingGroup,Value=play_with_aws_web_service_with_ecs
 ```
 
-### 更新コマンド
-```sh
-aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs-ecr \
-  --capabilities CAPABILITY_NAMED_IAM \
-  --template-body file://ecr.yaml
-```
+#### スタックの更新
 
 ```sh
 aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs \
@@ -34,19 +54,13 @@ aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs 
   --template-body file://main.yaml
 ```
 
-### 削除コマンド
-```sh
-aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs-ecr
-```
+#### スタックの削除
 
 ```sh
 aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs
 ```
 
-### イベント確認コマンド
-```sh
-aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs-ecr
-```
+### イベントの確認
 
 ```sh
 aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs

--- a/cloud_formation/web_service_with_ecs/README.md
+++ b/cloud_formation/web_service_with_ecs/README.md
@@ -5,16 +5,28 @@
 ## 手順
 
 ### 作成コマンド
+```sh
+aws cloudformation create-stack \
+   --stack-name play-with-aws-web-service-with-ecs-ecr \
+   --capabilities CAPABILITY_NAMED_IAM \
+   --template-body file://ecr.yaml \
+   --tags Key=Project,Value=play_with_aws Key=Identifier,Value=web_service_with_ecs Key=CmBillingGroup,Value=play_with_aws_web_service_with_ecs
+```
 
 ```sh
 aws cloudformation create-stack \
    --stack-name play-with-aws-web-service-with-ecs \
    --capabilities CAPABILITY_NAMED_IAM \
    --template-body file://main.yaml \
-   --tags Key=Project,Value=play_with_aws Key=Identifier,Value=web_service_with_ecs
+   --tags Key=Project,Value=play_with_aws Key=Identifier,Value=web_service_with_ecs Key=CmBillingGroup,Value=play_with_aws_web_service_with_ecs
 ```
 
 ### 更新コマンド
+```sh
+aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs-ecr \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --template-body file://ecr.yaml
+```
 
 ```sh
 aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs \
@@ -23,12 +35,18 @@ aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs 
 ```
 
 ### 削除コマンド
+```sh
+aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs-ecr
+```
 
 ```sh
 aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs
 ```
 
 ### イベント確認コマンド
+```sh
+aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs-ecr
+```
 
 ```sh
 aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs

--- a/cloud_formation/web_service_with_ecs/README.md
+++ b/cloud_formation/web_service_with_ecs/README.md
@@ -31,7 +31,7 @@ aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs-
 #### イベントの確認
 
 ```sh
-aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs-ecr
+aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs-ecr --output text
 ```
 
 ### Webアプリケーション環境の構築
@@ -63,5 +63,5 @@ aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs
 ### イベントの確認
 
 ```sh
-aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs
+aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs --output text
 ```

--- a/cloud_formation/web_service_with_ecs/README.md
+++ b/cloud_formation/web_service_with_ecs/README.md
@@ -5,6 +5,7 @@
 ## 手順
 
 ### 作成コマンド
+
 ```sh
 aws cloudformation create-stack \
    --stack-name play-with-aws-web-service-with-ecs \
@@ -13,18 +14,19 @@ aws cloudformation create-stack \
 ```
 
 ### 更新コマンド
+
 ```sh
-aws cloudformation update-stack \
-   --stack-name play-with-aws-web-service-with-ecs \
-   --template-body file://main.yaml \
+aws cloudformation update-stack --stack-name play-with-aws-web-service-with-ecs --template-body file://main.yaml
 ```
 
 ### 削除コマンド
+
 ```sh
 aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs
 ```
 
 ### イベント確認コマンド
+
 ```sh
 aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs
 ```

--- a/cloud_formation/web_service_with_ecs/README.md
+++ b/cloud_formation/web_service_with_ecs/README.md
@@ -1,0 +1,30 @@
+# AWS ECSを使用したWebアプリケーション環境の構築
+
+## 構成図
+
+## 手順
+
+### 作成コマンド
+```sh
+aws cloudformation create-stack \
+   --stack-name play-with-aws-web-service-with-ecs \
+   --template-body file://main.yaml \
+   --tags Key=Project,Value=play_with_aws Key=Identifier,Value=web_service_with_ecs
+```
+
+### 更新コマンド
+```sh
+aws cloudformation update-stack \
+   --stack-name play-with-aws-web-service-with-ecs \
+   --template-body file://main.yaml \
+```
+
+### 削除コマンド
+```sh
+aws cloudformation delete-stack --stack-name play-with-aws-web-service-with-ecs
+```
+
+### イベント確認コマンド
+```sh
+aws cloudformation describe-stack-events --stack-name play-with-aws-web-service-with-ecs
+```

--- a/cloud_formation/web_service_with_ecs/docker_files/Dockerfile
+++ b/cloud_formation/web_service_with_ecs/docker_files/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:latest
+
+RUN service nginx start
+
+EXPOSE 80

--- a/cloud_formation/web_service_with_ecs/docker_files/Dockerfile
+++ b/cloud_formation/web_service_with_ecs/docker_files/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:latest
 
-RUN service nginx start
+COPY index.html /usr/share/nginx/html
 
 EXPOSE 80

--- a/cloud_formation/web_service_with_ecs/docker_files/index.html
+++ b/cloud_formation/web_service_with_ecs/docker_files/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html lang=”ja”>
+  <head>
+    <meta charset="UTF-8">
+    <title>Hello, World</title>
+  </head>
+  <body>
+    <h1>Hello, World</h1>
+  </body>
+</html>

--- a/cloud_formation/web_service_with_ecs/ecr.yaml
+++ b/cloud_formation/web_service_with_ecs/ecr.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: 'Web Service with ECS'
+
+Outputs:
+  ECRPrivateRepository:
+    Description: ECR Private Repository For play_with_aws_web_service_with_ecs
+    Value: !GetAtt ECRPrivateRepository.RepositoryUri
+    Export:
+      Name: play-with-aws-web-service-with-ecs-ecr
+
+Resources:
+  ECRPrivateRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: play_with_aws_web_service_with_ecs # リポジトリ名
+      EmptyOnDelete: true
+      ImageTagMutability: MUTABLE # タブのイミュータビリティ
+      Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -181,6 +181,7 @@ Resources:
               - "sts:AssumeRole"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
       Tags:
         - Key: Project
           Value: play_with_aws

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -414,7 +414,7 @@ Resources:
           ReadonlyRootFilesystem: false # 読み取り専用ルートファイルシステム
           LogConfiguration: # ログ記録
             LogDriver: awslogs
-            Options: { 'awslogs-group': '/ecs/', 'awslogs-region': 'us-west-2', 'awslogs-stream-prefix': 'ecs', 'awslogs-create-group': 'true' }
+            Options: { 'awslogs-group': '/ecs/play_with_aws_web_service_with_ecs', 'awslogs-region': 'us-west-2', 'awslogs-stream-prefix': 'ecs', 'awslogs-create-group': 'true' }
           HealthCheck: # HealthCheck
               Command:
                 - CMD-SHELL

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -151,6 +151,38 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  TargetGroupForALB:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: with-aws-web-service-with-ecs
+      TargetType: ip
+      Protocol: HTTPS
+      Port: 443
+      IpAddressType: ipv4
+      VpcId: !Ref VPC
+      ProtocolVersion: HTTP2
+      HealthCheckEnabled: true
+      HealthCheckProtocol: HTTP
+      HealthCheckPath: /
+      HealthCheckPort: 80
+      HealthyThresholdCount: 5
+      UnhealthyThresholdCount: 2
+      HealthCheckTimeoutSeconds: 5
+      HealthCheckIntervalSeconds: 30
+      Matcher:
+        HttpCode: 200-299
+      # TargetGroupAttributes:
+      #   - TargetGroupAttribute
+      # Targets:
+      #   - TargetDescription
+      Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
   ECRRepository:
     Type: AWS::ECR::Repository
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -18,6 +18,25 @@ Resources:
         - Key: Identifier
           Value: web_service_with_ecs
 
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC # VPC
+      CidrBlock: 10.0.1.0/24 # IPv4 CIDR
+      AvailabilityZone: us-west-2a # アベイラビリティーゾーン
+      MapPublicIpOnLaunch: true # パブリック IPv4 アドレスを自動割り当て
+      # Ipv6CidrBlock: String
+      # Ipv6Native: Boolean
+      # AssignIpv6AddressOnCreation: Boolean
+      # EnableDns64: Boolean # DNS64 を有効化
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs_public_subnet_1
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -205,20 +205,6 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
-  ECRRepository:
-    Type: AWS::ECR::Repository
-    Properties:
-      RepositoryName: play_with_aws_web_service_with_ecs # リポジトリ名
-      EmptyOnDelete: true
-      ImageTagMutability: MUTABLE # タブのイミュータビリティ
-      Tags:
-        - Key: Project
-          Value: play_with_aws
-        - Key: Identifier
-          Value: web_service_with_ecs
-        - Key: CmBillingGroup
-          Value: play_with_aws_web_service_with_ecs
-
   IAMRoleExecuteECSTask:
     Type: AWS::IAM::Role
     Properties:
@@ -275,7 +261,7 @@ Resources:
         - Name: Nginx # 名前
           Image: !Join # イメージURI
             - ''
-            - - !GetAtt ECRRepository.RepositoryUri
+            - - !ImportValue play-with-aws-web-service-with-ecs-ecr
               - ':latest'
           Essential: true # 必須コンテナ
           PortMappings: # ポートマッピング

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: 'Web Service with ECS'
+
+Conditions:
+  HasNot: !Equals [ 'true', 'false' ]
+
+Resources:
+  NullResource:
+    Type: 'Custom::NullResource'
+    Condition: HasNot

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -205,6 +205,20 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  ListenerForALB:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Protocol: HTTP
+      Port: 80
+      DefaultActions: # To create additional rules for an Application Load Balancer, use AWS::ElasticLoadBalancingV2::ListenerRule.
+        - Type: forward
+          # ForwardConfig:
+          #   TargetGroupStickinessConfig: # グループレベルの維持設定
+          #     Enabled: true
+          #     DurationSeconds: 86400
+          TargetGroupArn: !Ref TargetGroupForALB
+
   IAMRoleExecuteECSTask:
     Type: AWS::IAM::Role
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -332,6 +332,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
       Tags:
         - Key: Project
           Value: play_with_aws

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -183,6 +183,28 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  ALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: pw-aws-web-service-with-ecs
+      Type: application
+      IpAddressType: ipv4
+      Scheme: internet-facing
+      # LoadBalancerAttributes:
+      #   - LoadBalancerAttribute
+      SecurityGroups:
+        - !Ref SecurityGroupForALB
+      Subnets:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+      Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
   ECRRepository:
     Type: AWS::ECR::Repository
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -3,6 +3,21 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: 'Web Service with ECS'
 
 Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsHostnames: false
+      EnableDnsSupport: false
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+
   ECRRepository:
     Type: AWS::ECR::Repository
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -131,6 +131,12 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref RouteTableForPublic
+      SubnetId: !Ref PublicSubnet1
+
   PublicSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
@@ -151,6 +157,12 @@ Resources:
           Value: web_service_with_ecs
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
+
+  PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref RouteTableForPublic
+      SubnetId: !Ref PublicSubnet2
 
   SecurityGroupForALB:
     Type: AWS::EC2::SecurityGroup
@@ -195,6 +207,12 @@ Resources:
           Value: web_service_with_ecs
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
+
+  PrivateSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref RouteTableForPrivate
+      SubnetId: !Ref PrivateSubnet1
 
   SecurityGroupForECS:
     Type: AWS::EC2::SecurityGroup

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -107,6 +107,9 @@ Resources:
       VpcEndpointType: Gateway
       ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
       VpcId: !Ref VPC
+      RouteTableIds:
+        - !Ref RouteTableForPublic
+        - !Ref RouteTableForPrivate
       PolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -160,7 +160,7 @@ Resources:
       Port: 80
       IpAddressType: ipv4
       VpcId: !Ref VPC
-      ProtocolVersion: HTTP2
+      ProtocolVersion: HTTP1
       HealthCheckEnabled: true
       HealthCheckProtocol: HTTP
       HealthCheckPath: /
@@ -268,7 +268,7 @@ Resources:
             - Name: http
               Protocol: tcp
               HostPort: 80
-              AppProtocol: http2
+              AppProtocol: http
               ContainerPort: 80
           ReadonlyRootFilesystem: false # 読み取り専用ルートファイルシステム
           LogConfiguration: # ログ記録

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -70,6 +70,13 @@ Resources:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
 
+  RouteToInternetGatewayForPublic:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref RouteTableForPublic
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
   VPCEndpointInterfaceForECRDKR:
     Type: AWS::EC2::VPCEndpoint
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -44,6 +44,29 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  SecurityGroupForECS:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: play_with_aws_web_service_with_ecs_for_ecs
+      GroupDescription: play_with_aws_web_service_with_ecs_for_ecs
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - Description: Allow HTTP access from anywhere
+          IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+          FromPort: 80
+          ToPort: 80
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -156,8 +156,8 @@ Resources:
     Properties:
       Name: with-aws-web-service-with-ecs
       TargetType: ip
-      Protocol: HTTPS
-      Port: 443
+      Protocol: HTTP
+      Port: 80
       IpAddressType: ipv4
       VpcId: !Ref VPC
       ProtocolVersion: HTTP2

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -23,6 +23,34 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  RouteTableForPublic:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs_public
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
+  RouteTableForPrivate:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs_private
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
   InternetGateway:
     Type: AWS::EC2::InternetGateway
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -46,3 +46,81 @@ Resources:
           Value: play_with_aws
         - Key: Identifier
           Value: web_service_with_ecs
+
+  ECSTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: play_with_aws_web_service_with_ecs # タスク定義ファミリー名
+      RequiresCompatibilities: # 起動タイプ
+        - FARGATE
+      RuntimePlatform: # オペレーティングシステム／アーキテクチャ
+        OperatingSystemFamily: LINUX
+        CpuArchitecture: X86_64
+      NetworkMode: awsvpc # ネットワークモード
+      Cpu: 256 # タスクサイズ-CPU
+      Memory: 512 # タスクサイズ-メモリ
+      #TaskRoleArn:  # タスクロール
+      ExecutionRoleArn: !Ref IAMRoleExecuteECSTask # 実行ロール
+      ContainerDefinitions: # コンテナ
+        # 必須コンテナ
+        - Name: Nginx # 名前
+          Image: !Join # イメージURI
+            - ''
+            - - !GetAtt ECRRepository.RepositoryUri
+              - ':latest'
+          Essential: true # 必須コンテナ
+          PortMappings: # ポートマッピング
+            - Name: http
+              Protocol: tcp
+              HostPort: 80
+              AppProtocol: http2
+              ContainerPort: 80
+          ReadonlyRootFilesystem: true # 読み取り専用ルートファイルシステム
+          LogConfiguration: # ログ記録
+            LogDriver: awslogs
+            Options: { 'awslogs-group': '/ecs/', 'awslogs-region': 'us-west-2', 'awslogs-stream-prefix': 'ecs', 'awslogs-create-group': 'true' }
+          HealthCheck: # HealthCheck
+              Command:
+                - CMD-SHELL
+                - curl -f http://localhost/ || exit 1
+              Interval: 60
+              Timeout: 60
+              StartPeriod: 30
+              Retries: 2
+          # DependsOn:
+          #   - ContainerDependency
+          # DisableNetworking: Boolean
+          # DnsSearchDomains:
+          #   - String
+          # DnsServers:
+          #   - String
+          # DockerSecurityOptions:
+          #   - String
+          # ExtraHosts:
+          #   - HostEntry
+          # FirelensConfiguration:
+          #   FirelensConfiguration
+          # Hostname: String
+          # Interactive: Boolean
+          # Links:
+          #   - String
+          # LinuxParameters:
+          #   LinuxParameters
+          # MountPoints:
+          #   - MountPoint
+          # Privileged: Boolean
+          # PseudoTerminal: Boolean
+          # ResourceRequirements:
+          #   - ResourceRequirement
+          # Secrets:
+          #   - Secret
+          # SystemControls:
+          #   - SystemControl
+          # User: String
+          # VolumesFrom:
+          #   - VolumeFrom
+      Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -230,7 +230,7 @@ Resources:
               HostPort: 80
               AppProtocol: http2
               ContainerPort: 80
-          ReadonlyRootFilesystem: true # 読み取り専用ルートファイルシステム
+          ReadonlyRootFilesystem: false # 読み取り専用ルートファイルシステム
           LogConfiguration: # ログ記録
             LogDriver: awslogs
             Options: { 'awslogs-group': '/ecs/', 'awslogs-region': 'us-west-2', 'awslogs-stream-prefix': 'ecs', 'awslogs-create-group': 'true' }

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -15,6 +15,28 @@ Resources:
         - Key: Identifier
           Value: web_service_with_ecs
 
+  IAMRoleExecuteECSTask:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: play_with_aws_web_service_with_ecs_execute_ecs_task
+      Description: play_with_aws_web_service_with_ecs
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ecs-tasks.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+
   ECSCluster:
     Type: AWS::ECS::Cluster
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -23,6 +23,19 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
   PublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -36,6 +36,12 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  VPCInternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
   PublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -84,10 +84,10 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
-  SecurityGroupForECS:
+  SecurityGroupForALB:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupName: play_with_aws_web_service_with_ecs_for_ecs
+      GroupName: play_with_aws_web_service_with_ecs_for_ecs_alb
       GroupDescription: play_with_aws_web_service_with_ecs_for_ecs
       VpcId: !Ref VPC
       SecurityGroupIngress:
@@ -121,6 +121,29 @@ Resources:
       Tags:
         - Key: Name
           Value: play_with_aws_web_service_with_ecs_private_subnet_1
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
+  SecurityGroupForECS:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: play_with_aws_web_service_with_ecs_for_ecs_ecs
+      GroupDescription: play_with_aws_web_service_with_ecs_for_ecs
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - Description: Allow HTTP access from ALB
+          IpProtocol: tcp
+          SourceSecurityGroupId: !Ref SecurityGroupForALB
+          FromPort: 80
+          ToPort: 80
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
         - Key: Project
           Value: play_with_aws
         - Key: Identifier

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -18,6 +18,25 @@ Resources:
         - Key: Identifier
           Value: web_service_with_ecs
 
+  PrivateSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC # VPC
+      CidrBlock: 10.0.4.0/24 # IPv4 CIDR
+      AvailabilityZone: us-west-2a # アベイラビリティーゾーン
+      MapPublicIpOnLaunch: false # パブリック IPv4 アドレスを自動割り当て
+      # Ipv6CidrBlock: String
+      # Ipv6Native: Boolean
+      # AssignIpv6AddressOnCreation: Boolean
+      # EnableDns64: Boolean # DNS64 を有効化
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs_private_subnet_1
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+
   ECRRepository:
     Type: AWS::ECR::Repository
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -2,10 +2,13 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Description: 'Web Service with ECS'
 
-Conditions:
-  HasNot: !Equals [ 'true', 'false' ]
-
 Resources:
-  NullResource:
-    Type: 'Custom::NullResource'
-    Condition: HasNot
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: play_with_aws_web_service_with_ecs
+      Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -10,8 +10,8 @@ Resources:
     Type: AWS::EC2::VPC
     Properties:
       CidrBlock: 10.0.0.0/16
-      EnableDnsHostnames: false
-      EnableDnsSupport: false
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
       InstanceTenancy: default
       Tags:
         - Key: Name
@@ -41,6 +41,46 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
+
+  VPCEndpointInterfaceForECRDKR:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcEndpointType: Interface
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.dkr
+      VpcId: !Ref VPC
+      PrivateDnsEnabled: true
+      SubnetIds:
+        - !Ref PrivateSubnet1
+      SecurityGroupIds:
+        - !Ref SecurityGroupForECS
+
+  VPCEndpointInterfaceForECRAPI:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcEndpointType: Interface
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.api
+      VpcId: !Ref VPC
+      PrivateDnsEnabled: true
+      SubnetIds:
+        - !Ref PrivateSubnet1
+      SecurityGroupIds:
+        - !Ref SecurityGroupForECS
+
+  VPCEndpointGatewayForS3:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcEndpointType: Gateway
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
+      VpcId: !Ref VPC
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal: '*'
+            Action:
+              - 's3:GetObject'
+            Resource:
+              - !Sub arn:aws:s3:::prod-${AWS::Region}-starport-layer-bucket/*
 
   PublicSubnet1:
     Type: AWS::EC2::Subnet

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -475,3 +475,52 @@ Resources:
           Value: web_service_with_ecs
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
+
+  ECSService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref ECSCluster
+      # 環境
+      LaunchType: FARGATE # 起動タイプ
+      PlatformVersion: LATEST # プラットフォームのバージョン
+      # デプロイ設定
+      # アプリケーションタイプ
+      # タスク定義
+      # リビジョンの手動指定
+      TaskDefinition: !Ref ECSTask # ファミリー & リビジョン
+      ServiceName: play_with_aws_web_service_with_ecs # サービス名
+      # サービスタイプ
+      DesiredCount: 1 # 必要なタスク
+      DeploymentController:
+        Type: CODE_DEPLOY
+      DeploymentConfiguration: # デプロイオプション
+        MinimumHealthyPercent: 100 # 最小実行タスク
+        MaximumPercent: 200 # 最大実行タスク
+      NetworkConfiguration: # ネットワーキング
+        AwsvpcConfiguration:
+          Subnets: # サブネット
+            - !Ref PrivateSubnet1
+          SecurityGroups: # セキュリティグループ
+            - !Ref SecurityGroupForECS
+          AssignPublicIp: DISABLED # パブリックIP
+      LoadBalancers: # ロードバランシング
+        - ContainerName: Nginx
+          ContainerPort: 80
+          TargetGroupArn: !Ref TargetGroupForALB
+      # EnableExecuteCommand: Boolean
+      # HealthCheckGracePeriodSeconds: Integer
+      # PlacementStrategies:
+      #   - PlacementStrategy
+      # Role: String
+      # SchedulingStrategy: String
+      EnableECSManagedTags: true # Amazon ECS マネージドタグを有効にする
+      PropagateTags: TASK_DEFINITION # タグの伝播元
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs_public_subnet_1
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -103,6 +103,19 @@ Resources:
       SecurityGroupIds:
         - !Ref SecurityGroupForVPCE
 
+  VPCEndpointInterfaceForCloudWatchLogs:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcEndpointType: Interface
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.logs
+      VpcId: !Ref VPC
+      PrivateDnsEnabled: true
+      SubnetIds:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+      SecurityGroupIds:
+        - !Ref SecurityGroupForVPCE
+
   VPCEndpointGatewayForS3:
     Type: AWS::EC2::VPCEndpoint
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -85,9 +85,10 @@ Resources:
       VpcId: !Ref VPC
       PrivateDnsEnabled: true
       SubnetIds:
-        - !Ref PrivateSubnet1
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
       SecurityGroupIds:
-        - !Ref SecurityGroupForECS
+        - !Ref SecurityGroupForVPCE
 
   VPCEndpointInterfaceForECRAPI:
     Type: AWS::EC2::VPCEndpoint
@@ -97,9 +98,10 @@ Resources:
       VpcId: !Ref VPC
       PrivateDnsEnabled: true
       SubnetIds:
-        - !Ref PrivateSubnet1
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
       SecurityGroupIds:
-        - !Ref SecurityGroupForECS
+        - !Ref SecurityGroupForVPCE
 
   VPCEndpointGatewayForS3:
     Type: AWS::EC2::VPCEndpoint
@@ -240,6 +242,31 @@ Resources:
         - IpProtocol: -1
           CidrIp: 0.0.0.0/0
       Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
+  SecurityGroupForVPCE:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: play_with_aws_web_service_with_ecs_for_vpce
+      GroupDescription: play_with_aws_web_service_with_ecs_for_vpce
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - Description: Allow HTTPS access from ECS
+          IpProtocol: tcp
+          SourceSecurityGroupId: !Ref SecurityGroupForECS
+          FromPort: 443
+          ToPort: 443
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs_for_vpce
         - Key: Project
           Value: play_with_aws
         - Key: Identifier

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -180,7 +180,9 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: play_with_aws_web_service_with_ecs_for_ecs_alb
+      #GroupName: play_with_aws_web_service_with_ecs_for_alb
       GroupDescription: play_with_aws_web_service_with_ecs_for_ecs
+      #GroupDescription: play_with_aws_web_service_with_ecs_for_alb
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - Description: Allow HTTP access from anywhere
@@ -230,6 +232,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: play_with_aws_web_service_with_ecs_for_ecs_ecs
+      #GroupName: play_with_aws_web_service_with_ecs_for_ecs
       GroupDescription: play_with_aws_web_service_with_ecs_for_ecs
       VpcId: !Ref VPC
       SecurityGroupIngress:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -3,6 +3,18 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: 'Web Service with ECS'
 
 Resources:
+  ECRRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: play_with_aws_web_service_with_ecs # リポジトリ名
+      EmptyOnDelete: true
+      ImageTagMutability: MUTABLE # タブのイミュータビリティ
+      Tags:
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+
   ECSCluster:
     Type: AWS::ECS::Cluster
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -44,6 +44,27 @@ Resources:
         - Key: CmBillingGroup
           Value: play_with_aws_web_service_with_ecs
 
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC # VPC
+      CidrBlock: 10.0.2.0/24 # IPv4 CIDR
+      AvailabilityZone: us-west-2b # アベイラビリティーゾーン
+      MapPublicIpOnLaunch: true # パブリック IPv4 アドレスを自動割り当て
+      # Ipv6CidrBlock: String
+      # Ipv6Native: Boolean
+      # AssignIpv6AddressOnCreation: Boolean
+      # EnableDns64: Boolean # DNS64 を有効化
+      Tags:
+        - Key: Name
+          Value: play_with_aws_web_service_with_ecs_public_subnet_2
+        - Key: Project
+          Value: play_with_aws
+        - Key: Identifier
+          Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
+
   SecurityGroupForECS:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/cloud_formation/web_service_with_ecs/main.yaml
+++ b/cloud_formation/web_service_with_ecs/main.yaml
@@ -2,6 +2,9 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Description: 'Web Service with ECS'
 
+Conditions:
+  HasNot: !Equals [ 'true', 'false' ]
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -17,6 +20,8 @@ Resources:
           Value: play_with_aws
         - Key: Identifier
           Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
 
   PublicSubnet1:
     Type: AWS::EC2::Subnet
@@ -36,6 +41,8 @@ Resources:
           Value: play_with_aws
         - Key: Identifier
           Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
 
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
@@ -55,6 +62,8 @@ Resources:
           Value: play_with_aws
         - Key: Identifier
           Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
 
   ECRRepository:
     Type: AWS::ECR::Repository
@@ -67,6 +76,8 @@ Resources:
           Value: play_with_aws
         - Key: Identifier
           Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
 
   IAMRoleExecuteECSTask:
     Type: AWS::IAM::Role
@@ -89,6 +100,8 @@ Resources:
           Value: play_with_aws
         - Key: Identifier
           Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
 
   ECSCluster:
     Type: AWS::ECS::Cluster
@@ -99,6 +112,8 @@ Resources:
           Value: play_with_aws
         - Key: Identifier
           Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs
 
   ECSTask:
     Type: AWS::ECS::TaskDefinition
@@ -177,3 +192,5 @@ Resources:
           Value: play_with_aws
         - Key: Identifier
           Value: web_service_with_ecs
+        - Key: CmBillingGroup
+          Value: play_with_aws_web_service_with_ecs


### PR DESCRIPTION
## はまりポイント
### ECSサービスの構築時
```
ネットワークインターフェイスの記述中にエラーが発生しました。
The networkInterface ID 'eni-1234567890abcdef' does not exist

タスクの停止時刻: 2023-10-14T13:37:28.378Z
ResourceInitializationError: unable to pull secrets or registry auth: 
execution resource retrieval failed: unable to retrieve ecr registry auth: 
service call has been retried 3 time(s): RequestError: send request failed caused by: 
Post "https://api.ecr.us-west-2.amazonaws.com/": dial tcp: lookup api.ecr.us-west-2.amazonaws.com: i/o timeout. 
Please check your task network configuration.
```

#### 参考
- https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/vpc-endpoints.html

### VPCエンドポイントの構築時
```
Resource handler returned message: "Enabling private DNS requires both enableDnsSupport and enableDnsHostnames VPC attributes set to true for vpc-0c4b88e633111dfbd (Service: Ec2, Status Code: 400, Request ID: 0aae018c-2ff8-4108-8f05-fd23735b6df6)" (RequestToken: bcf2bfa8-77cd-a2c8-5b2d-6aa08a5ce0d9, HandlerErrorCode: GeneralServiceException)
```

#### 参考
- https://soypocket.com/it/vpcendpoint-error-dns-check/

### VPCエンドポイントにNameタグを指定しようとした際
```
Properties validation failed for resource VPCEndpointForECRAPI with message: #: extraneous key [Tags] is not permitted
```

### ECSタスク起動時に
```
ResourceInitializationError: failed to validate logger args: : signal: killed
```
<img width="1005" alt="ResourceInitializationError" src="https://github.com/koba-masa/play_with_aws/assets/37115710/787007ac-97ca-495b-ae33-6c5e0e2e3829">

#### 参考
- https://blog.not75743.com/post/ecs_private/
